### PR TITLE
add support for more than one BrowserWindow filename

### DIFF
--- a/lib/opal/electron/browser_window.rb
+++ b/lib/opal/electron/browser_window.rb
@@ -4,10 +4,10 @@ module Electron
   class BrowserWindow
     include Native
 
-    def initialize(name, params = {}, debug: false)
+    def initialize(name = 'main_window', params = {}, debug: false)
       `var { BrowserWindow } = require('electron')`
       @native = JS.new(`BrowserWindow`, `params.$to_n()`)
-      @native.JS.loadURL("file://#{`__dirname`}/main_window.html")
+      @native.JS.loadURL("file://#{`__dirname`}/#{name}.html")
       @native.JS[:webContents].JS.openDevTools if debug
     end
 


### PR DESCRIPTION
* previously all instances of BrowserWindow would ignore the `name`
  parameter and would use "main_window.html".
* now BrowserWindow's initializer will use the name parameter
  when determining the filename to load