### PR TITLE
simplify BrowserWindow initialization syntax

### DIFF
--- a/lib/opal/electron/browser_window.rb
+++ b/lib/opal/electron/browser_window.rb
@@ -4,7 +4,9 @@ module Electron
   class BrowserWindow
     include Native
 
-    def initialize(name = 'main_window', params = {}, debug: false)
+    def initialize(name = 'main_window', params = {})
+      debug = params[:debug]
+      params.delete(:debug)
       `var { BrowserWindow } = require('electron')`
       @native = JS.new(`BrowserWindow`, `params.$to_n()`)
       @native.JS.loadURL("file://#{`__dirname`}/#{name}.html")


### PR DESCRIPTION
* now can specify debug as part of params hash
* debug option properly removed before passing along to electron
* new syntax example: `BrowserWindow.new 'win', width: 100, debug: true`

This one is a bit of a matter of personal preference so I totally understand if you don't want to merge. I originally spent 40 minutes changing things around before I realized that the API was _not_ set up this way.

Argument for: it is confusing and awkward to have a params hash followed by a named parameter

Argument against: it is confusing to have an extra `debug` param that is not built into electron