### PR TITLE
add ruby support for BrowserWindow instance methods

### DIFF
--- a/lib/opal/electron/browser_window.rb
+++ b/lib/opal/electron/browser_window.rb
@@ -9,8 +9,26 @@ module Electron
       @native = JS.new(`BrowserWindow`, `params.$to_n()`)
       @native.JS.loadURL("file://#{`__dirname`}/#{name}.html")
       @native.JS[:webContents].JS.openDevTools if debug
+      methods_ruby = []
+      %x{
+        for(var method in #@native) {
+          #{methods_ruby << `method`}
+        }
+      }
+      methods_ruby.each do |method|
+        next if method[0] == '_'
+        BrowserWindow.instance_eval do
+          if method.index('is') == 0
+            alias_native (method.delete('is') + '?').to_sym, method.to_sym
+          elsif method.index('set') == 0
+            alias_native (method.delete('set') + '=').to_sym, method.to_sym
+          elsif method.index('get') == 0
+            alias_native method.delete('get').to_sym, method.to_sym
+          else
+            alias_native method.to_sym
+          end
+        end
+      end
     end
-
-    alias_native :on
   end
 end


### PR DESCRIPTION
* getters use original method name minus 'get'
* setters use ruby setter (original_method_name=)
* booleans use original_method_name?